### PR TITLE
Configure Ruby version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.gem
 *.rbc
+.rbenv-gemsets
+.ruby-version
+/.gems
 /.config
 /coverage/
 /InstalledFiles

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a small helper script to generate and send attendees a certificate PDF b
 Prerequisite
 ============
 
-In order to run this script you need [ruby 2.2.2+](http://www.ruby-lang.org/) installed and [bundler](http://bundler.io/).
+In order to run this script you need [ruby 2.3.1+](http://www.ruby-lang.org/) installed and [bundler](http://bundler.io/).
 
 How to Use
 ==========
@@ -46,4 +46,3 @@ Development
 ===========
 
 You can start guard with ``dev.sh`` or just run all tests with ``bundle exec rake``.
-

--- a/lib/generate_certificates.rb
+++ b/lib/generate_certificates.rb
@@ -19,7 +19,7 @@ def build_options_from(arguments)
       smtp: {
         address: ENV['SMTP_SERVER'],
         port: ENV['SMTP_PORT'] || '587',
-        domain: ENV['SENDER'].try(:split, '@').try(:[], 1),
+        domain: ENV['SENDER'] && ENV['SENDER'].split('@').last,
         authentication: ENV['AUTHENTICATION'] || 'plain',
         user_name: ENV['SENDER'],
         password: ENV['SMTP_PASSWORD']
@@ -42,7 +42,7 @@ begin
   csv_content = File.read(configuration.csv_filepath)
   svg_content = File.read(configuration.svg_filepath)
   body_template = File.read(configuration.body_template_path)
-  
+
   configuration.delivery.install_on(ActionMailer::Base)
 
   generator = CertificateGenerator.new(svg_content,


### PR DESCRIPTION
Suggesting these changes after trying to run this software for the first time. Basically, this PR determines the ruby version in the `.ruby-version` used by [rbenv](https://github.com/rbenv/rbenv) and fixes a code that is not compatible with Ruby v2.3.1.